### PR TITLE
Revert the red warning line on the weekly wellness plot

### DIFF
--- a/Dashboardexample.Rmd
+++ b/Dashboardexample.Rmd
@@ -177,6 +177,7 @@ renderPlot({
     geom_line() + 
     scale_colour_gradient(low="red", high="green", guide = FALSE) +
     geom_hline(yintercept= 0, lty=3) +
+    geom_hline(yintercept= -2, colour="red", lty=1, alpha=2.5/10) +
     facet_grid(Name ~., switch = "y") +
     scale_x_date(date_breaks = "1 day", date_labels =  "%a") +
     theme(axis.title=element_blank(), 


### PR DESCRIPTION
How about this ? (is it supposed to be at -2 or -2.5 ?) 

<img width="1239" alt="screen shot 2018-05-11 at 22 08 50" src="https://user-images.githubusercontent.com/40331/39946955-13469f6e-5568-11e8-8fc6-b9b094798016.png">
